### PR TITLE
Add an option for increased touch sensitivity on Pixel devices.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -2776,6 +2776,10 @@
     <string name="adaptive_sleep_contextual_slice_title">Turn on screen attention</string>
     <!-- Description about the contextual adaptive sleep card [CHAR LIMIT=NONE]-->
     <string name="adaptive_sleep_contextual_slice_summary">Keep screen on when looking at it</string>
+    <!-- Display settings screen, increased touch sensitivity settings title [CHAR LIMIT=30] -->
+    <string name="touch_sens_title">Increase touch sensitivity</string>
+    <!-- Display settings screen, increased touch sensitivity settings summary [CHAR LIMIT=NONE] -->
+    <string name="touch_sens_summary">Improves touch when using screen protectors</string>
 
     <!-- Night display screen, setting option name to enable night display (renamed "Night Light" with title caps). [CHAR LIMIT=30] -->
     <string name="night_display_title">Night Light</string>

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -131,6 +131,12 @@
         settings:controller="com.android.settings.security.screenlock.LockScreenPreferenceController" />
 
     <SwitchPreference
+        android:key="touch_sens"
+        android:title="@string/touch_sens_title"
+        settings:keywords="@string/touch_sens_summary"
+        settings:controller="com.android.settings.display.TouchSensitivityPreferenceController" />
+
+    <SwitchPreference
         android:key="camera_gesture"
         android:title="@string/camera_gesture_title"
         android:summary="@string/camera_gesture_desc" />

--- a/src/com/android/settings/display/TouchSensitivityPreferenceController.java
+++ b/src/com/android/settings/display/TouchSensitivityPreferenceController.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2021 The Proton AOSP Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.display;
+
+import android.content.Context;
+import android.os.SystemProperties;
+
+import androidx.preference.Preference;
+import androidx.preference.SwitchPreference;
+
+import com.android.settings.core.PreferenceControllerMixin;
+import com.android.settingslib.core.AbstractPreferenceController;
+
+public class TouchSensitivityPreferenceController extends AbstractPreferenceController
+        implements Preference.OnPreferenceChangeListener, PreferenceControllerMixin {
+
+    private static final String TOUCH_SENS_KEY = "touch_sens";
+    static final String TOUCH_SENS_PROPERTY = "persist.vendor.touch_sensitivity_mode";
+
+    public TouchSensitivityPreferenceController(Context context) {
+        super(context);
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return mContext.getResources().getBoolean(com.android.internal.R.bool.config_supportGloveMode);
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return TOUCH_SENS_KEY;
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        final boolean isEnabled = (Boolean) newValue;
+        SystemProperties.set(TOUCH_SENS_PROPERTY, isEnabled ? "1" : "0");
+        return true;
+    }
+
+    @Override
+    public void updateState(Preference preference) {
+        final boolean isEnabled = SystemProperties.getBoolean(TOUCH_SENS_PROPERTY, false);
+        ((SwitchPreference) preference).setChecked(isEnabled);
+    }
+}


### PR DESCRIPTION
This requires a partner commit in FWB which adds the config overlay for
devices to opt-in to supporting this feature.

This feature isn't Pixel-exclusive, however other devices will need
additional configuration within their ramdisks to allow controlling
glove mode via the persist.vendor.touch_sensitivity_mode system
property.

Signed-off-by: Diab Neiroukh <lazerl0rd@thezest.dev>